### PR TITLE
Fixes for FTP + SFTP

### DIFF
--- a/mod_clamav.c
+++ b/mod_clamav.c
@@ -117,7 +117,7 @@ static int clamavd_result(int sockd, const char *abs_filename, const char *rel_f
       proto = pr_session_get_protocol(0);
       if (strncmp(proto, "ftp", 3) == 0 ||
           strncmp(proto, "ftps", 4) == 0) {
-        pr_response_send(R_550, "Virus Detected and Removed: %s", pt);
+        pr_response_add_err(R_550, "Virus Detected and Removed: %s", pt);
       }
 
       /* Log the fact */
@@ -578,7 +578,10 @@ static int clamav_fsio_close(pr_fh_t *fh, int fd) {
                    MOD_CLAMAV_VERSION ": notice    : unlink() failed (%d): %s",
                    errno, strerror(errno));
       }
+      errno = EPERM;
+      return -1;
     }
+  } else if (res) {
     errno = EPERM;
     return -1;
   }


### PR DESCRIPTION
Fix how the 550 virus found message is sent so that it doesn't break client-side handling.
Change when it returns EPERM so that fail-safe mode off works and mod_sftp also works.

These 2 changes were required to make mod_clamav work with the latest proftpd master (1.3.9rc1-ish)