### PR TITLE
Replace end_login with pr_session_end

### DIFF
--- a/mod_clamav.c
+++ b/mod_clamav.c
@@ -239,7 +239,7 @@ static int clamavd_scan_stream(int sockd, const char *abs_filename,
   buf = malloc(bufsz);
   if (!buf) {
     pr_log_pri(PR_LOG_CRIT, "Out of memory!");
-    end_login(1);
+    pr_session_end(1);
   }
 
   /* send file contents using protocol defined by Clamd */


### PR DESCRIPTION
As of 1.3.9rc2, end_login is no longer defined in compat.h, and must be replaced with pr_session_end in order to compile.