### PR TITLE
Fix clam scanning path issues when using mod_vroot

### DIFF
--- a/mod_clamav.c
+++ b/mod_clamav.c
@@ -516,11 +516,13 @@ static int clamav_fsio_close(pr_fh_t *fh, int fd) {
     (void) pr_trace_msg("clamav", 8, "vwd=%s fh_path=%s chroot=%s cwd=%s buf=%s",
                         pr_fs_getvwd(), abs_path, session.chroot_path, pr_fs_getcwd(),
                         buf);
-    if (strcmp(buf, pr_fs_getcwd()) != 0) {
-      if (strcmp(pr_fs_getcwd(), "/") != 0) {
-        char *pos = strstr(buf, pr_fs_getcwd());
-        if (pos) {
-          *pos = 0;
+    if (session.chroot_path && strcmp(session.chroot_path, "/") != 0) {
+      if (strcmp(buf, pr_fs_getcwd()) != 0) {
+        if (strcmp(pr_fs_getcwd(), "/") != 0) {
+          char *pos = strstr(buf, pr_fs_getcwd());
+          if (pos) {
+            *pos = 0;
+          }
         }
       }
 


### PR DESCRIPTION
When using mod_vroot, the chroot path gets prepended to the scan path when it isn't needed.  This fixes that problem.  (I can't remember exactly why it was that this is needed because it's been so long since I did my investigation, and I had forgotten about submitting a PR for it, but without it doing non-stream scans with mod_vroot doesn't work because the path passed to clamd looks like /vroot/path/vroot/path/jailed/path rather than just /vroot/path/jailed/path).